### PR TITLE
can now use opencv 3.0

### DIFF
--- a/CMT.cpp
+++ b/CMT.cpp
@@ -19,8 +19,13 @@ void CMT::initialize(const Mat im_gray, const Rect rect)
     Point2f center = Point2f(rect.x + rect.width/2.0, rect.y + rect.height/2.0);
 
     //Initialize detector and descriptor
+#if CV_MAJOR_VERSION > 2
+    detector = cv::FastFeatureDetector::create();
+    descriptor = cv::BRISK::create();
+#else
     detector = FeatureDetector::create(str_detector);
     descriptor = DescriptorExtractor::create(str_descriptor);
+#endif
 
     //Get initial keypoints in whole image and compute their descriptors
     vector<KeyPoint> keypoints;

--- a/gui.cpp
+++ b/gui.cpp
@@ -1,6 +1,9 @@
 #include "gui.h"
 
 #include <opencv2/highgui/highgui.hpp>
+#if CV_MAJOR_VERSION > 2
+# include <opencv2/imgproc.hpp>
+#endif
 
 using cv::setMouseCallback;
 using cv::Point;


### PR DESCRIPTION
Two small changes that allows OpenCV 3.0 to be used. The strings defining which type of detector and descriptor to use will be ignored when using OpenCV 3.0, since the needed creator functions are missing.
