### PR TITLE
Skip frames at the start of a video file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ For example, vc12 is to be used for Visual Studio 2013.
 
 # Usage
 ```
-usage: ./cmt [--challenge] [--no-scale] [--with-rotation] [--bbox BBOX] [inputpath]
+usage: ./cmt [--challenge] [--no-scale] [--with-rotation] [--bbox BBOX] [--skip N] [inputpath]
 ```
 ## Optional arguments
 * `inputpath` The input path.
@@ -60,6 +60,7 @@ usage: ./cmt [--challenge] [--no-scale] [--with-rotation] [--bbox BBOX] [inputpa
 * `--no-scale` Disable scale estimation
 * `--with-rotation` Enable rotation estimation
 * `--bbox BBOX` Specify initial bounding box. Format: x,y,w,h
+* `--skip N` Skip N frames of the video input
 
 ## Object Selection
 Press any key to stop the preview stream. Left click to select the

--- a/main.cpp
+++ b/main.cpp
@@ -82,6 +82,7 @@ int main(int argc, char **argv)
     int loop_flag = 0;
     int verbose_flag = 0;
     int bbox_flag = 0;
+    int skip_frames = 0;
     string input_path;
 
     const int detector_cmd = 1000;
@@ -89,6 +90,7 @@ int main(int argc, char **argv)
     const int bbox_cmd = 1002;
     const int no_scale_cmd = 1003;
     const int with_rotation_cmd = 1004;
+    const int skip_cmd = 1005;
 
     struct option longopts[] =
     {
@@ -102,6 +104,7 @@ int main(int argc, char **argv)
         {"bbox", required_argument, 0, bbox_cmd},
         {"detector", required_argument, 0, detector_cmd},
         {"descriptor", required_argument, 0, descriptor_cmd},
+        {"skip", required_argument, 0, skip_cmd},
         {0, 0, 0, 0}
     };
 
@@ -135,6 +138,15 @@ int main(int argc, char **argv)
                 break;
             case descriptor_cmd:
                 cmt.str_descriptor = optarg;
+                break;
+            case skip_cmd:
+                {
+                    int ret = sscanf(optarg, "%d", &skip_frames);
+                    if (ret != 1)
+                    {
+                      skip_frames = 0;
+                    }
+                }
                 break;
             case no_scale_cmd:
                 cmt.consensus.estimate_scale = false;
@@ -262,6 +274,12 @@ int main(int argc, char **argv)
     else
     {
         cap.open(input_path);
+
+        if (skip_frames > 0)
+        {
+          cap.set(CV_CAP_PROP_POS_FRAMES, skip_frames);
+        }
+
         show_preview = false;
     }
 

--- a/main.cpp
+++ b/main.cpp
@@ -96,12 +96,12 @@ int main(int argc, char **argv)
         {"challenge", no_argument, &challenge_flag, 1},
         {"loop", no_argument, &loop_flag, 1},
         {"verbose", no_argument, &verbose_flag, 1},
+        {"no-scale", no_argument, 0, no_scale_cmd},
+        {"with-rotation", no_argument, 0, with_rotation_cmd},
         //Argument options
         {"bbox", required_argument, 0, bbox_cmd},
         {"detector", required_argument, 0, detector_cmd},
         {"descriptor", required_argument, 0, descriptor_cmd},
-        {"no-scale", no_argument, 0, no_scale_cmd},
-        {"with-rotation", no_argument, 0, with_rotation_cmd},
         {0, 0, 0, 0}
     };
 


### PR DESCRIPTION
This adds the --skip=N argument equivalent to the python CMT version. Also documented in the README.
