### PR TITLE
Skip the first N milliseconds at the start of a video file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ For example, vc12 is to be used for Visual Studio 2013.
 
 # Usage
 ```
-usage: ./cmt [--challenge] [--no-scale] [--with-rotation] [--bbox BBOX] [--skip N] [inputpath]
+usage: ./cmt [--challenge] [--no-scale] [--with-rotation] [--bbox BBOX] [--skip N] [--skip-msecs] [inputpath]
 ```
 ## Optional arguments
 * `inputpath` The input path.
@@ -61,6 +61,10 @@ usage: ./cmt [--challenge] [--no-scale] [--with-rotation] [--bbox BBOX] [--skip 
 * `--with-rotation` Enable rotation estimation
 * `--bbox BBOX` Specify initial bounding box. Format: x,y,w,h
 * `--skip N` Skip N frames of the video input
+* `--skip-msecs N` Skip N milliseconds of the video input
+
+Trying to skip both frames and milliseconds at the start of a video will raise
+an error.
 
 ## Object Selection
 Press any key to stop the preview stream. Left click to select the

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ For example, vc12 is to be used for Visual Studio 2013.
 
 # Usage
 ```
-usage: ./cmt [--challenge] [--no-scale] [--with-rotation] [--bbox BBOX] [--skip N] [--skip-msecs] [inputpath]
+usage: ./cmt [--challenge] [--no-scale] [--with-rotation] [--bbox BBOX] [--skip N] [--skip-msecs N] [inputpath]
 ```
 ## Optional arguments
 * `inputpath` The input path.

--- a/main.cpp
+++ b/main.cpp
@@ -83,6 +83,7 @@ int main(int argc, char **argv)
     int verbose_flag = 0;
     int bbox_flag = 0;
     int skip_frames = 0;
+    int skip_msecs = 0;
     string input_path;
 
     const int detector_cmd = 1000;
@@ -91,6 +92,7 @@ int main(int argc, char **argv)
     const int no_scale_cmd = 1003;
     const int with_rotation_cmd = 1004;
     const int skip_cmd = 1005;
+    const int skip_msecs_cmd = 1006;
 
     struct option longopts[] =
     {
@@ -105,6 +107,7 @@ int main(int argc, char **argv)
         {"detector", required_argument, 0, detector_cmd},
         {"descriptor", required_argument, 0, descriptor_cmd},
         {"skip", required_argument, 0, skip_cmd},
+        {"skip-msecs", required_argument, 0, skip_msecs_cmd},
         {0, 0, 0, 0}
     };
 
@@ -148,6 +151,15 @@ int main(int argc, char **argv)
                     }
                 }
                 break;
+            case skip_msecs_cmd:
+                {
+                    int ret = sscanf(optarg, "%d", &skip_msecs);
+                    if (ret != 1)
+                    {
+                      skip_msecs = 0;
+                    }
+                }
+                break;
             case no_scale_cmd:
                 cmt.consensus.estimate_scale = false;
                 break;
@@ -158,6 +170,13 @@ int main(int argc, char **argv)
                 return 1;
         }
 
+    }
+
+    // Can only skip frames or milliseconds, not both.
+    if (skip_frames > 0 && skip_msecs > 0)
+    {
+      cerr << "You can only skip frames, or milliseconds, not both." << endl;
+      return 1;
     }
 
     //One argument remains
@@ -278,6 +297,11 @@ int main(int argc, char **argv)
         if (skip_frames > 0)
         {
           cap.set(CV_CAP_PROP_POS_FRAMES, skip_frames);
+        }
+
+        if (skip_msecs > 0)
+        {
+          cap.set(CV_CAP_PROP_POS_MSEC, skip_msecs);
         }
 
         show_preview = false;


### PR DESCRIPTION
Raises an error if you try to skip both frames and milliseconds.

This would be really useful to have for me as I know how many seconds I need to skip (rather than the number of frames) and doing it this way would be preferable than working out the framerate and calculating the number of frames to skip from that, I think.
