### PR TITLE
Ensure frame numbers are correct after skipping.

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -353,7 +353,7 @@ int main(int argc, char **argv)
     //Initialize CMT
     cmt.initialize(im0_gray, rect);
 
-    int frame = 0;
+    int frame = skip_frames;
 
     //Main loop
     while (true)

--- a/main.cpp
+++ b/main.cpp
@@ -302,6 +302,9 @@ int main(int argc, char **argv)
         if (skip_msecs > 0)
         {
           cap.set(CV_CAP_PROP_POS_MSEC, skip_msecs);
+
+          // Now which frame are we on?
+          skip_frames = (int) cap.get(CV_CAP_PROP_POS_FRAMES);
         }
 
         show_preview = false;


### PR DESCRIPTION
If frames are skipped at the start of the input video (with either the --skip or --skip-msecs arguments) then the frame counter should be updated to reflect this.

When I initially added the skipping code I mimicked the python version of CMT and didn't update the frame counter, but on reflection I think this should be done. It'll make the output clearer.
