### PR TITLE
Output data to a file

### DIFF
--- a/CMT.cpp
+++ b/CMT.cpp
@@ -18,6 +18,9 @@ void CMT::initialize(const Mat im_gray, const Rect rect)
     //Compute center of rect
     Point2f center = Point2f(rect.x + rect.width/2.0, rect.y + rect.height/2.0);
 
+    //Initialize rotated bounding box
+    bb_rot = RotatedRect(center, size_initial, 0.0);
+
     //Initialize detector and descriptor
 #if CV_MAJOR_VERSION > 2
     detector = cv::FastFeatureDetector::create();

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ For example, vc12 is to be used for Visual Studio 2013.
 
 # Usage
 ```
-usage: ./cmt [--challenge] [--no-scale] [--with-rotation] [--bbox BBOX] [--skip N] [--skip-msecs N] [inputpath]
+usage: ./cmt [--challenge] [--no-scale] [--with-rotation] [--bbox BBOX] [--skip N] [--skip-msecs N] [--output-file FILE] [inputpath]
 ```
 ## Optional arguments
 * `inputpath` The input path.
@@ -62,6 +62,7 @@ usage: ./cmt [--challenge] [--no-scale] [--with-rotation] [--bbox BBOX] [--skip 
 * `--bbox BBOX` Specify initial bounding box. Format: x,y,w,h
 * `--skip N` Skip N frames of the video input
 * `--skip-msecs N` Skip N milliseconds of the video input
+* `--output-file FILE` Save data to a file in CSV format
 
 Trying to skip both frames and milliseconds at the start of a video will raise
 an error.
@@ -88,5 +89,13 @@ It is also possible to specify the initial bounding box on the command line:
 ```
 cmt --bbox=123,85,60,140 test.avi
 ```
+
+You can output data (number of active points, bounding box parameters) to a
+file in CSV format:
+```
+cmt --output-file=/path/to/file.csv test.avi
+```
+The data file includes header data so that it can be loaded into Excel or R
+directly.
 
 [1]: http://en.wikipedia.org/wiki/BSD_licenses#2-clause_license_.28.22Simplified_BSD_License.22_or_.22FreeBSD_License.22.29

--- a/main.cpp
+++ b/main.cpp
@@ -6,6 +6,7 @@
 
 #include <iostream>
 #include <fstream>
+#include <sstream>
 #include <cstdio>
 
 #ifdef __GNUC__
@@ -67,6 +68,25 @@ int display(Mat im, CMT & cmt)
     imshow(WIN_NAME, im);
 
     return waitKey(5);
+}
+
+string write_rotated_rect(RotatedRect rect)
+{
+    Point2f verts[4];
+    rect.points(verts);
+    stringstream coords;
+
+    coords << rect.center.x << "," << rect.center.y << ",";
+    coords << rect.size.width << "," << rect.size.height << ",";
+    coords << rect.angle << ",";
+
+    for (int i = 0; i < 4; i++)
+    {
+        coords << verts[i].x << "," << verts[i].y;
+        if (i != 3) coords << ",";
+    }
+
+    return coords.str();
 }
 
 int main(int argc, char **argv)

--- a/main.cpp
+++ b/main.cpp
@@ -33,6 +33,15 @@ using std::endl;
 using ::atof;
 
 static string WIN_NAME = "CMT";
+static string OUT_FILE_COL_HEADERS =
+    "Frame,Timestamp (ms),Active points,"\
+    "Bounding box centre X (px),Bounding box centre Y (px),"\
+    "Bounding box width (px),Bounding box height (px),"\
+    "Bounding box rotation (degrees),"\
+    "Bounding box vertex 1 X (px),Bounding box vertex 1 Y (px),"\
+    "Bounding box vertex 2 X (px),Bounding box vertex 2 Y (px),"\
+    "Bounding box vertex 3 X (px),Bounding box vertex 3 Y (px),"\
+    "Bounding box vertex 4 X (px),Bounding box vertex 4 Y (px)";
 
 vector<float> getNextLineAndSplitIntoFloats(istream& str)
 {
@@ -394,6 +403,7 @@ int main(int argc, char **argv)
         int msecs = (int) cap.get(CV_CAP_PROP_POS_MSEC);
 
         output_file.open(output_path.c_str());
+        output_file << OUT_FILE_COL_HEADERS << endl;
         output_file << frame << "," << msecs << ",";
         output_file << cmt.points_active.size() << ",";
         output_file << write_rotated_rect(cmt.bb_rot) << endl;

--- a/main.cpp
+++ b/main.cpp
@@ -386,6 +386,19 @@ int main(int argc, char **argv)
 
     int frame = skip_frames;
 
+    //Open output file.
+    ofstream output_file;
+
+    if (output_flag)
+    {
+        int msecs = (int) cap.get(CV_CAP_PROP_POS_MSEC);
+
+        output_file.open(output_path.c_str());
+        output_file << frame << "," << msecs << ",";
+        output_file << cmt.points_active.size() << ",";
+        output_file << write_rotated_rect(cmt.bb_rot) << endl;
+    }
+
     //Main loop
     while (true)
     {
@@ -409,13 +422,27 @@ int main(int argc, char **argv)
         //Let CMT process the frame
         cmt.processFrame(im_gray);
 
+        //Output.
+        if (output_flag)
+        {
+            int msecs = (int) cap.get(CV_CAP_PROP_POS_MSEC);
+            output_file << frame << "," << msecs << ",";
+            output_file << cmt.points_active.size() << ",";
+            output_file << write_rotated_rect(cmt.bb_rot) << endl;
+        }
+        else
+        {
+            //TODO: Provide meaningful output
+            FILE_LOG(logINFO) << "#" << frame << " active: " << cmt.points_active.size();
+        }
+
+        //Display image and then quit if requested.
         char key = display(im, cmt);
-
         if(key == 'q') break;
-
-        //TODO: Provide meaningful output
-        FILE_LOG(logINFO) << "#" << frame << " active: " << cmt.points_active.size();
     }
+
+    //Close output file.
+    if (output_flag) output_file.close();
 
     return 0;
 }

--- a/main.cpp
+++ b/main.cpp
@@ -84,7 +84,9 @@ int main(int argc, char **argv)
     int bbox_flag = 0;
     int skip_frames = 0;
     int skip_msecs = 0;
+    int output_flag = 0;
     string input_path;
+    string output_path;
 
     const int detector_cmd = 1000;
     const int descriptor_cmd = 1001;
@@ -93,6 +95,7 @@ int main(int argc, char **argv)
     const int with_rotation_cmd = 1004;
     const int skip_cmd = 1005;
     const int skip_msecs_cmd = 1006;
+    const int output_file_cmd = 1007;
 
     struct option longopts[] =
     {
@@ -106,6 +109,7 @@ int main(int argc, char **argv)
         {"bbox", required_argument, 0, bbox_cmd},
         {"detector", required_argument, 0, detector_cmd},
         {"descriptor", required_argument, 0, descriptor_cmd},
+        {"output-file", required_argument, 0, output_file_cmd},
         {"skip", required_argument, 0, skip_cmd},
         {"skip-msecs", required_argument, 0, skip_msecs_cmd},
         {0, 0, 0, 0}
@@ -141,6 +145,10 @@ int main(int argc, char **argv)
                 break;
             case descriptor_cmd:
                 cmt.str_descriptor = optarg;
+                break;
+            case output_file_cmd:
+                output_path = optarg;
+                output_flag = 1;
                 break;
             case skip_cmd:
                 {


### PR DESCRIPTION
This pull request enables CppMT to output tracking data to a file in CSV format. The data that is output is number of active points, plus all the RotatedRect data (centre, rotation, size, vertices). I've optimized the output data for loading into other tools, such as Excel or R, so it's all in one file (as opposed to one per frame for the python version).
