### PR TITLE
cmake switch for dynamic or static CRT in Visual Studio

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,12 @@ project (CMT)
 cmake_minimum_required (VERSION 2.6)
 
 option(BUILD_TRAX_CLIENT "Build the trax client." OFF)
+set(BUILD_WITH_STATIC_CRT "Manual flags" CACHE STRING "Use statically linked CRT")
+set_property(CACHE BUILD_WITH_STATIC_CRT PROPERTY STRINGS "Manual flags" "Yes" "No")
+
+if(MSVC)
+  include(cmake/msvc_crt.cmake)
+endif(MSVC)
 
 find_package(OpenCV REQUIRED)
 

--- a/cmake/msvc_crt.cmake
+++ b/cmake/msvc_crt.cmake
@@ -1,0 +1,37 @@
+if(NOT MSVC)
+  message(FATAL_ERROR "CRT options are available only for MSVC")
+endif()
+
+if(${BUILD_WITH_STATIC_CRT} MATCHES "Yes")
+  foreach(flag_var
+          CMAKE_C_FLAGS CMAKE_C_FLAGS_DEBUG CMAKE_C_FLAGS_RELEASE
+          CMAKE_C_FLAGS_MINSIZEREL CMAKE_C_FLAGS_RELWITHDEBINFO
+          CMAKE_CXX_FLAGS CMAKE_CXX_FLAGS_DEBUG CMAKE_CXX_FLAGS_RELEASE
+          CMAKE_CXX_FLAGS_MINSIZEREL CMAKE_CXX_FLAGS_RELWITHDEBINFO)
+    if(${flag_var} MATCHES "/MD")
+      string(REGEX REPLACE "/MD" "/MT" ${flag_var} "${${flag_var}}")
+    endif()
+    if(${flag_var} MATCHES "/MDd")
+      string(REGEX REPLACE "/MDd" "/MTd" ${flag_var} "${${flag_var}}")
+    endif()
+    set(${flag_var} "${${flag_var}}" CACHE STRING "" FORCE)
+  endforeach(flag_var)
+
+  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /NODEFAULTLIB:atlthunk.lib /NODEFAULTLIB:msvcrt.lib /NODEFAULTLIB:msvcrtd.lib")
+  set(CMAKE_EXE_LINKER_FLAGS_DEBUG "${CMAKE_EXE_LINKER_FLAGS_DEBUG} /NODEFAULTLIB:libcmt.lib")
+  set(CMAKE_EXE_LINKER_FLAGS_RELEASE "${CMAKE_EXE_LINKER_FLAGS_RELEASE} /NODEFAULTLIB:libcmtd.lib")
+elseif(${BUILD_WITH_STATIC_CRT} MATCHES "No")
+  foreach(flag_var
+          CMAKE_C_FLAGS CMAKE_C_FLAGS_DEBUG CMAKE_C_FLAGS_RELEASE
+          CMAKE_C_FLAGS_MINSIZEREL CMAKE_C_FLAGS_RELWITHDEBINFO
+          CMAKE_CXX_FLAGS CMAKE_CXX_FLAGS_DEBUG CMAKE_CXX_FLAGS_RELEASE
+          CMAKE_CXX_FLAGS_MINSIZEREL CMAKE_CXX_FLAGS_RELWITHDEBINFO)
+    if(${flag_var} MATCHES "/MT")
+      string(REGEX REPLACE "/MT" "/MD" ${flag_var} "${${flag_var}}")
+    endif()
+    if(${flag_var} MATCHES "/MTd")
+      string(REGEX REPLACE "/MTd" "/MDd" ${flag_var} "${${flag_var}}")
+    endif()
+    set(${flag_var} "${${flag_var}}" CACHE STRING "" FORCE)
+  endforeach(flag_var)
+endif()


### PR DESCRIPTION
Added a dropdown in cmake-gui for switching between static and dynamic CRT in Visual Studio on Windows. Default option is "Manual flags", which means that no change is made in the flags.
