### PR TITLE
Fixed #27. Updated consensus to compute centroid only when at least two points are available

### DIFF
--- a/Consensus.cpp
+++ b/Consensus.cpp
@@ -105,8 +105,8 @@ void Consensus::findConsensus(const vector<Point2f> & points, const vector<int> 
 {
     FILE_LOG(logDEBUG) << "Consensus::findConsensus() call";
 
-    //If no points are available, reteurn nan
-    if (points.size() == 0)
+    //If at least two points are not available, return nan
+    if (points.size() < 2)
     {
         center.x = numeric_limits<float>::quiet_NaN();
         center.y = numeric_limits<float>::quiet_NaN();


### PR DESCRIPTION
This fixes a crash in **findConsensus** when _exactly one_ keypoint is available.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gnebehay/cppmt/31)

<!-- Reviewable:end -->
